### PR TITLE
Add Docker build tests and Jest frontend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Run frontend unit tests
+        working-directory: frontend
+        run: npm test -- --runInBand
+      - name: Build Docker images
+        run: docker-compose build
+      - name: Start containers
+        run: docker-compose up -d
+      - name: Wait for backend
+        run: |
+          for i in {1..10}; do
+            curl -s http://localhost:5000/api/hello && break || sleep 3
+          done
+      - name: Test backend endpoint
+        run: curl -s http://localhost:5000/api/hello | grep -q 'Hello from Flask backend'
+      - name: Test frontend endpoint
+        run: curl -s http://localhost:5173 | grep -q 'RAG Pipeline Frontend'
+      - name: Stop containers
+        run: docker-compose down

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -1,0 +1,5 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
+};

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -19,6 +20,11 @@
     "postcss": "^8.4.0",
     "tailwindcss": "^3.0.0",
     "typescript": "^5.0.0",
-    "vite": "^4.5.14"
+    "vite": "^4.5.14",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.0.0",
+    "@types/jest": "^29.5.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders title', () => {
+  render(<App />);
+  expect(screen.getByText(/RAG Pipeline Frontend/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Docker images, run them and curl health checks
- add Jest setup with React Testing Library
- test that `App` renders expected title

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*
- `docker-compose build` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68426b49387c8329bce0a7142795044b