### PR TITLE
Fix CI jest execution

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -2,7 +2,7 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },
   transform: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "jest",
+    "test": "node node_modules/jest/bin/jest.js",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- fix Jest module mapper field in `jest.config.ts`
- run Jest via node to avoid permission issues

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844a49a4d3c8329bd60285af4b87e02